### PR TITLE
fix(wordle): increment error_count on invalid guesses in verifiers toolkit

### DIFF
--- a/envs/wordle_env/verifiers/env.py
+++ b/envs/wordle_env/verifiers/env.py
@@ -59,6 +59,8 @@ class WordleToolkit:
         self._ensure_game()
         self.step_count += 1
         result = self._game.guess(word)
+        if "Invalid" in result:
+            self.error_count += 1
         self.last_output = result
         return result
 


### PR DESCRIPTION
`WordleToolkit` initialises `self.error_count` in `__init__` and clears it in `reset()`, but never increments it. It always reads 0, so invalid guesses are invisible to anything consuming the counter.

The other two Wordle harnesses already track this signal with the same check right after submitting the guess to the game:

- `envs/wordle_env/gem/env.py` — `if "Invalid" in result: self.error_count += 1`
- `envs/wordle_env/skyrl_gym/env.py` — same

This adds the identical two lines to the verifiers toolkit. No new mechanism.

### Why it matters

Shipping one Wordle task across three harnesses is only useful if a rollout is comparable no matter which harness produced it, and `error_count` is part of that surface — `gem` exports it as `info["error_count"]`, `skyrl_gym` as `metadata["errors"]`.

With the verifiers toolkit hard-reporting 0, any aggregate over a mixed rollout set silently under-counts invalid guesses, and the gap scales with the share of verifiers rollouts in the batch. That reads as "the model on the verifiers path emits cleaner guesses" when the real difference is that nobody was counting — exactly the kind of per-harness artifact that cross-harness stats exist to rule out.

The unparseable-action increment the other two harnesses also perform has no analogue here: the toolkit receives `word` as a typed tool argument, so there is no parse step.

### Testing

No test is included in the diff — `tests/` was intentionally dropped in 8ffa922, so this keeps to the existing layout. Verified out-of-tree instead: two invalid guesses (`"zz"`, `"12345"`) plus one valid guess, run either side of the change.

```
                       pre-patch    post-patch
  guess('zz') rejected     True         True
  guess('12345') rejected  True         True
  guess('stone') accepted  True         True
  step_count                  3            3
  error_count                 0  <-- x     2  <-- ok
  after reset()           0 / 0        0 / 0
```

Every other assertion is identical on both sides, so the check isolates this fix rather than passing either way.

Notes on the fixture: `"zz"` trips the length branch in `WordleGame.guess`, `"12345"` trips the `.isalpha()` branch, so both Invalid paths are covered. The answer is pinned with `set_answer("crane")` and the valid guess is `"stone"` — `WordleGame("")` picks a random word, and the guess is deliberately neither the answer nor the 6th attempt, so the valid-guess assertion is deterministic and non-terminal.

### Scope

One file, two added lines, no deletions (`git diff --numstat` → `2  0  envs/wordle_env/verifiers/env.py`). No reformatting, no import cleanup, nothing else touched.
