### PR TITLE
Link the gallery Space from the manifest and the results README

### DIFF
--- a/02-watercolour/project.yaml
+++ b/02-watercolour/project.yaml
@@ -9,6 +9,7 @@ hub:
   spaces:
     - HuggingEnvs/watercolour-env
     - HuggingEnvs/watercolour-hpsv3
+    - HuggingEnvs/watercolour-gallery
     - HuggingEnvs/watercolour-trackio-hps-only
     - HuggingEnvs/watercolour-trackio-judge-led
     - HuggingEnvs/watercolour-trackio-hps-led

--- a/02-watercolour/results/README.md
+++ b/02-watercolour/results/README.md
@@ -23,6 +23,8 @@ CSV, versioned alongside the code that produced them.
 | `VERSIONS.md` | the package versions the uv header resolved around launch day |
 | `fig-flat-controls-vs-hps-only.png` | `hps-only` against the three flat controls that came before it |
 
+Every painting of every run is browsable in [the gallery Space](https://huggingface.co/spaces/HuggingEnvs/watercolour-gallery), by step and by reward, with the sketch that made each one.
+
 Columns: `reward`, `reward_std`, `frac_reward_zero_std`, `entropy`, `loss`,
 `grad_norm`, `learning_rate`, `step_time`, `completions/mean_length`,
 `clipped_ratio`, and the group means of each reward term (`judge_mean`,


### PR DESCRIPTION
Adds [HuggingEnvs/watercolour-gallery](https://huggingface.co/spaces/HuggingEnvs/watercolour-gallery) (a static Space where every painting of every run is browsable by step and reward, with its sketch) to `project.yaml` and to `results/README.md`.